### PR TITLE
job:  #MUN-172  syntax support for unhappy events

### DIFF
--- a/src/plus2json.g4
+++ b/src/plus2json.g4
@@ -12,6 +12,7 @@ umlblock       : STARTUML ( '(' 'id' '=' identifier ')' )? NEWLINE
                ;
 
 job_defn       : PARTITION job_name '{' NEWLINE sequence_defn+ '}' NEWLINE
+                 ( PACKAGE package_name '{' NEWLINE unhappy_event* '}' NEWLINE )*
                ;
 
 job_name       : identifier
@@ -39,6 +40,7 @@ event_defn     : ( HIDE NEWLINE )?
                    | merge_count
                    | loop_count
                    | invariant
+                   | critical
                    )*
                  ( ';' | '<' | '>' | ']' )
                  ( NEWLINE ( break | detach ) )?
@@ -69,6 +71,9 @@ invariant      : ',' ( IINV | EINV )
                  ( ',' SRC ( '=' sname=identifier ( '(' socc=number ')' )? )? )?
                  ( ',' USER ( '=' uname=identifier ( '(' uocc=number ')' )? )? )?
                  ',' NAME '=' invname=identifier
+               ;
+
+critical       : ',' CRITICAL
                ;
 
 break          : BREAK
@@ -128,6 +133,18 @@ split          : SPLIT NEWLINE
 split_again    : SPLITAGAIN NEWLINE statement+
                ;
 
+package_name   : identifier
+               ;
+
+unhappy_event  : PACKAGE package_name '{' NEWLINE unhappy_event* '}' NEWLINE
+               | ':' unhappy_name
+                 ( ';' | '<' | '>' | ']' )
+                 NEWLINE KILL NEWLINE
+               ;
+
+unhappy_name   : identifier
+               ;
+
 identifier     : IDENT
                | StringLiteral // allowing blanks delimited with double-quotes
                ;
@@ -143,6 +160,7 @@ StringLiteral  : '"' ( ~('\\'|'"') )* '"'
 BCNT           : 'bcnt' | 'BCNT'; // branch count
 BREAK          : 'break';
 CASE           : 'case';
+CRITICAL       : 'critical' | 'CRITICAL';
 DETACH         : 'detach';
 EINV           : 'einv' | 'EINV'; // extra-job invariant
 ELSE           : 'else';
@@ -159,9 +177,11 @@ GROUP          : 'group';         // sequence
 HIDE           : '-[hidden]->';
 IF             : 'if';
 IINV           : 'iinv' | 'IINV'; // intra-job invariant
+KILL           : 'kill';
 LCNT           : 'lcnt' | 'LCNT'; // loop count
 MCNT           : 'mcnt' | 'MCNT'; // merge count
 NAME           : 'name' | 'NAME'; // marking target event
+PACKAGE        : 'package';       // grouping of unsequenced events
 PARTITION      : 'partition';     // job
 REPEAT         : 'repeat';
 SPLITAGAIN     : 'split again';
@@ -186,7 +206,7 @@ WS             : [ \t]+ -> skip ; // toss out whitespace
 //=========================================================
 // Fragments
 //=========================================================
-fragment NONDIGIT : [_a-zA-Z*];
+fragment NONDIGIT : [-_a-zA-Z*];
 fragment DIGIT :  [0-9];
 fragment UNSIGNED_INTEGER : DIGIT+;
 

--- a/tests/Tutorial_13.puml
+++ b/tests/Tutorial_13.puml
@@ -7,16 +7,16 @@ Tutorial - Intra-Job Invariant
 @startuml 
 partition "Job with Intra-Job Invariant" {
   group "Straight Sequence w/ Invariant"
-      #green:A,IINV,name=X;
+      #green:A13,IINV,name=X;
       note right 
         A carries an intra-job
         invariant named X
         targeted to E.
       end note
-      :B;
-      :C;
-      :D;
-      #red:E,IINV,USER,name=X;
+      :B13;
+      :C13;
+      :D13;
+      #red:E13,IINV,USER,name=X;
       note right 
         E is a user of intra-
         job invariant X.

--- a/tests/regress_parser.sh
+++ b/tests/regress_parser.sh
@@ -19,4 +19,5 @@ antlr4-parse ../src/plus2json.g4 plusdefn < Tutorial_15.puml
 antlr4-parse ../src/plus2json.g4 plusdefn < Tutorial_16.puml
 antlr4-parse ../src/plus2json.g4 plusdefn < Tutorial_17.puml
 antlr4-parse ../src/plus2json.g4 plusdefn < Tutorial_18.puml
+antlr4-parse ../src/plus2json.g4 plusdefn < unhappy_critical.puml
 echo "finished"

--- a/tests/unhappy_critical.puml
+++ b/tests/unhappy_critical.puml
@@ -1,0 +1,32 @@
+@startuml
+partition "Simple Job" {
+group "Fund Transfer"
+  :requestFunds;
+  :requestApproved;
+  #gold:fundsTransferred,CRITICAL;
+  detach
+end group
+}
+
+package "Unhappy Path Events" {
+  :unhappy-path-event-1;
+  kill
+  :unhappy-path-event-2;
+  kill
+  package "Unhappy Subevents" {
+    :unhappy-path-event-3;
+    kill
+    :unhappy-path-event-4;
+    kill
+  }
+  :unhappy-path-event-5;
+  kill
+  :unhappy-path-event-6;
+  kill
+}
+
+package "Another Unhappy Path Event" {
+  :unhappy-path-event-1;
+  kill
+}
+@enduml


### PR DESCRIPTION
The grammar has been updated to support the definition of unhappy path audit events.  'package' contains unhappy path events.  They must each be followed by 'kill'.  Multiple packages and nested packages are supported as long as they follow a single job definition 'partition'.