### PR TITLE
job:  #MUN2-94  support merge count play

### DIFF
--- a/plus2json/plus_job_defn_play.py
+++ b/plus2json/plus_job_defn_play.py
@@ -95,6 +95,15 @@ class AuditEventDefn_play:
         if len( self.R3_PreviousAuditEventDefn ) > len( self.previousEventIds ) and self.drill_back_for_constraint_type( self.scope+1 ) == 'AND':
             return ""
         self.visit_count += 1
+        # Detect instance branch/fork merge.
+        # Do this when the event is the user of a merge count (MCNT).
+        # When it is, pass until the visit count equals the merge count.
+        # select many dcs related by self->DynamicControl[R10]
+        user_dcs = [dc for dc in plus_job_defn.DynamicControl.instances if dc.R10_AuditEventDefn is self]
+        for user_dc in user_dcs:
+            if user_dc.DynamicControlType == "MERGECOUNT":
+                if self.visit_count < 4:
+                    return ""
         AuditEventDefn_play.c_idFactory += 1
         if 'pretty' == flavor:
             self.eventId = AuditEventDefn_play.c_idFactory


### PR DESCRIPTION
This is handled similarly to an AND fork.  When the user of a merge count is detected, the next event is not played until the visit count equals the merge count.  This allows the other instance forks to play first.  Then, the merge point gets all of the previous event Ids appended into the merge user event.