### PR TITLE
job:  #76  python 3.12 incompatibility

### DIFF
--- a/bundle.py
+++ b/bundle.py
@@ -7,12 +7,12 @@ import sys
 import xtuml
 import zipapp
 
-VERSION = '1.5.0'
+VERSION = '1.5.1'
 
 
 def gen_grammar():
     # generate Plus
-    print('Genearting Antlr Parser...')
+    print('Generating Antlr Parser...')
     argv = sys.argv
     sys.argv = ['', '-v', '4.13.0', '-Dlanguage=Python3', '-no-listener', '-visitor', '-o', 'plus2json/plus', '-Xexact-output-dir', 'grammar/Plus.g4']
     antlr4_tool_runner.tool()

--- a/plus2json/plus2json.py
+++ b/plus2json/plus2json.py
@@ -23,9 +23,7 @@ from .pretty_print import JobDefn_pretty_print
 from antlr4.error.Errors import CancellationException
 from importlib.resources import files
 from itertools import cycle
-# This works around a bug in python-kafka3 dependencies.
-if sys.version_info >= (3, 12, 0): sys.modules['kafka.vendor.six.moves'] = six.moves
-from kafka3 import KafkaProducer
+from kafka import KafkaProducer
 from stomp import Connection
 
 from xtuml import navigate_any as any

--- a/plus2json/plus2json.py
+++ b/plus2json/plus2json.py
@@ -23,6 +23,8 @@ from .pretty_print import JobDefn_pretty_print
 from antlr4.error.Errors import CancellationException
 from importlib.resources import files
 from itertools import cycle
+# This works around a bug in python-kafka3 dependencies.
+if sys.version_info >= (3, 12, 0): sys.modules['kafka.vendor.six.moves'] = six.moves
 from kafka3 import KafkaProducer
 from stomp import Connection
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 antlr4-python3-runtime==4.13.0
 pyxtuml==3.0.0
-kafka-python3==3.0.0
+kafka-python==2.1.4
 stomp.py==8.2.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if __name__ == '__main__':
           keywords='xtuml bridgepoint protocol verifier',
           packages=['plus2json', 'plus2json.plus', 'plus2json.schema'],
           package_data={'plus2json': ['version.json'], 'plus2json.plus': ['*.interp', '*.tokens'], 'plus2json.schema': ['plus_schema.sql']},
-          install_requires=['antlr4-python3-runtime==4.13.0', 'pyxtuml==3.0.0', 'kafka-python3==3.0.0', 'stomp.py==8.2.0'],
+          install_requires=['antlr4-python3-runtime==4.13.0', 'pyxtuml==3.0.0', 'kafka-python==2.1.4', 'stomp.py==8.2.0'],
           test_suite='tests',
           include_package_data=True,
           zip_safe=True)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 if __name__ == '__main__':
-    version='1.5.0',
+    version='1.5.1',
     setup(name='plus2json',
           description='PLUS Activity PlantUML Parser/Processor',
           author='Cortland Starrett',


### PR DESCRIPTION
kafka3 has a module dependency problem when running python 3.12.3. This fix is basically a (potentially permanent) work-around.